### PR TITLE
fix a POD typo, break a long line

### DIFF
--- a/lib/Tie/RDBM.pm
+++ b/lib/Tie/RDBM.pm
@@ -558,7 +558,7 @@ strings types will work as well.
 
 In a future version of this module, the "frozen" field may be turned
 into a general "datatype" field in order to minimize storage.  For
-future compatability, please use an integer for the frozen field.
+future compatibility, please use an integer for the frozen field.
 
 If you use the "create" and/or "drop" options, the module will
 automatically attempt to create a table for its own use in the
@@ -623,7 +623,8 @@ B<Process #1:>
 
 B<Process #2:>
    tie %i,'Tie::RDBM','mysql:Employees:host.somewhere.com',
-                   {table=>'employee',user=>'george',password=>'kumquat2'};
+                   {table=>'employee',user=>'george',
+                    password=>'kumquat2'};
    foreach (keys %i) {
       $info = $i{$_};
       if ($info->{age} > 30) {


### PR DESCRIPTION
This fixes a lintian (Debian QA tool) warning and a "can't break lines" error from man
