### PR TITLE
Fixes RT 104338 - prepare fails when a question mark appears in a text field

### DIFF
--- a/lib/Tie/DBI.pm
+++ b/lib/Tie/DBI.pm
@@ -390,9 +390,14 @@ sub _run_query {
     }
     local ($^W) = 0;    # kill uninitialized variable warning
                         # if we get here, then we can't bind, so we replace ? with escaped parameters
-    while ( ( my $pos = index( $query, '?' ) ) >= 0 ) {
+    my $pos = 0;
+    while ( ( $pos = index( $query, '?', $pos ) ) >= 0 ) {
         my $value = shift(@bind_variables);
-        substr( $query, $pos, 1 ) = ( defined($value) ? ( $self->{CanBind} ? $self->{'dbh'}->quote($value) : $value ) : 'null' );
+        $value = defined($value)
+                    ? ( $self->{CanBind} ? $self->{'dbh'}->quote($value) : $value )
+                    : 'null';
+        substr( $query, $pos, 1 ) = $value;
+        $pos += length($value);
     }
     my $sth = $self->{'dbh'}->prepare($query);
     return unless $sth && $sth->execute;

--- a/t/DBI.t
+++ b/t/DBI.t
@@ -26,7 +26,7 @@ unless ($DRIVER) {
 }
 
 if ($DRIVER) {
-    plan tests => 26;
+    plan tests => 27;
     diag("DBI.t - Using DBD driver $DRIVER...");
 }
 else {
@@ -183,3 +183,10 @@ my $before = TEST_STRING;
 $h{strawberries}->{description} = $before;
 my $after = $h{strawberries}->{description};
 is( $after, $before, "blanks aren't chopped" );
+
+# RT 104338 - prepare fails with a question mark in a text field
+use constant TEST_STRING_WITH_QUESTION_MARK => 'will this work? I hope so';
+$before = TEST_STRING_WITH_QUESTION_MARK;
+$h{strawberries}->{description} = $before;
+$after = $h{strawberries}->{description};
+is( $after, $before, 'question marks can appear in text fields');


### PR DESCRIPTION
This applies the fix given in the issue by Bruce Reed, and adds a test
