### PR TITLE
ci: bump install-with-cpm to @v2 so old Perls install deps

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -23,7 +23,7 @@ jobs:
       - name: perl -V
         run: perl -V
       - name: Install Dependencies
-        uses: perl-actions/install-with-cpm@v1
+        uses: perl-actions/install-with-cpm@v2
         with:
           cpanfile: "cpanfile"
       - name: Makefile.PL
@@ -45,7 +45,7 @@ jobs:
       - name: perl -V
         run: perl -V
       - name: Install Dependencies
-        uses: perl-actions/install-with-cpm@v1
+        uses: perl-actions/install-with-cpm@v2
         with:
           cpanfile: "cpanfile"
       - name: Makefile.PL
@@ -90,7 +90,7 @@ jobs:
       - name: perl -V
         run: perl -V
       - name: Install Dependencies
-        uses: perl-actions/install-with-cpm@v1
+        uses: perl-actions/install-with-cpm@v2
         with:
           sudo: false
           cpanfile: "cpanfile"
@@ -115,7 +115,7 @@ jobs:
       - name: perl -V
         run: perl -V
       - name: Install Dependencies
-        uses: perl-actions/install-with-cpm@v1
+        uses: perl-actions/install-with-cpm@v2
         with:
           sudo: false
           cpanfile: "cpanfile"
@@ -141,7 +141,7 @@ jobs:
       - name: perl -V
         run: perl -V
       - name: Install Dependencies
-        uses: perl-actions/install-with-cpm@v1
+        uses: perl-actions/install-with-cpm@v2
         with:
           sudo: false
           cpanfile: "cpanfile"


### PR DESCRIPTION
## Problem

CI fails on every Perl ≤ 5.22 (5.8, 5.10, 5.12, 5.14, 5.16, 5.18, 5.20, 5.22) — a clean boundary at 5.24. `MIN_PERL_VERSION` is `5.008` and the matrix tests `since-perl: 5.8`, so 5.22 is just the highest failing version, not a configured limit.

The failure is in the **Install Dependencies** step, not the tests. Commit `db41601` ("Modernize CI") pinned `perl-actions/install-with-cpm@v1` (an April 2024 tag). With its default `version: main`, that tag downloads the latest `cpm`, which since **cpm v0.999.0 requires Perl ≥ 5.24** (the "Lyon Amendment"):

```
Get cpm from URL: https://raw.githubusercontent.com/skaji/cpm/main/cpm
Perl v5.24.0 required--this is only v5.22.4, stopped at /usr/local/bin/cpm line 2.
BEGIN failed--compilation aborted at /usr/local/bin/cpm line 2.
```

The Tie-DBI code itself still works on old Perls — this is purely a CI tooling regression.

## Fix

Upstream already solved this in **install-with-cpm v2.4** ([perl-actions/install-with-cpm#96](https://github.com/perl-actions/install-with-cpm/pull/96)): when `version` resolves to `main`, no `checksum` is set, and the perl is < 5.24, the action auto-substitutes cpm `0.998003` (the last pre-Lyon release); modern Perls keep getting the latest cpm.

Bump all five `Install Dependencies` steps from `@v1` to `@v2` to consume that fix. This restores the 5.8–5.22 matrix without freezing modern Perls onto an old cpm.

CI-only change — no code, `$VERSION`, or `Changes` edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)